### PR TITLE
Track *_files/ if it exists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # tarchetypes 0.0.4.9000
 
 * Implement an external `walk_ast()` function to make it easier for other developers to extend the static code analysis of `tarchetypes` (@MilesMcBain).
+* In `tar_render()` and related functions, track the `*_files/` output directory if it exists (#30).
 
 # tarchetypes 0.0.4
 

--- a/R/tar_render.R
+++ b/R/tar_render.R
@@ -26,8 +26,9 @@
 #' @return A target object with `format = "file"`.
 #'   When this target runs, it returns a character vector
 #'   of file paths. The first file paths are the output files
-#'   (returned by `rmarkdown::render()`) and the R Markdown
-#'   source file is last. But unlike `rmarkdown::render()`,
+#'   (returned by `rmarkdown::render()`), including the `*_files/`
+#'   directory with supporting files if it exists, and the R Markdown
+#'   source file is last. Unlike `rmarkdown::render()`,
 #'   all returned paths are *relative* paths to ensure portability
 #'   (so that the project can be moved from one file system to another
 #'   without invalidating the target).

--- a/R/tar_render.R
+++ b/R/tar_render.R
@@ -25,10 +25,9 @@
 #'       in the target and `quiet = TRUE` in `rmarkdown::render()`.
 #' @return A target object with `format = "file"`.
 #'   When this target runs, it returns a character vector
-#'   of file paths. The first file paths are the output files
-#'   (returned by `rmarkdown::render()`), including the `*_files/`
-#'   directory with supporting files if it exists, and the R Markdown
-#'   source file is last. Unlike `rmarkdown::render()`,
+#'   of file paths: the rendered document, the source file,
+#'   and then the `*_files/` directory if it exists.
+#'   Unlike `rmarkdown::render()`,
 #'   all returned paths are *relative* paths to ensure portability
 #'   (so that the project can be moved from one file system to another
 #'   without invalidating the target).

--- a/R/tar_render_raw.R
+++ b/R/tar_render_raw.R
@@ -8,10 +8,9 @@
 #'   is a language object.
 #' @return A target object with `format = "file"`.
 #'   When this target runs, it returns a character vector
-#'   of file paths. The first file paths are the output files
-#'   (returned by `rmarkdown::render()`), including
-#'   the `*_files/` directory with supporting files if it exists,
-#'   and the R Markdown source file is last. Unlike `rmarkdown::render()`,
+#'   of file paths: the rendered document, the source file,
+#'   and then the `*_files/` directory if it exists.
+#'   Unlike `rmarkdown::render()`,
 #'   all returned paths are *relative* paths to ensure portability
 #'   (so that the project can be moved from one file system to another
 #'   without invalidating the target).
@@ -157,5 +156,5 @@ tar_render_paths <- function(output, source) {
   source <- fs::path_rel(source)
   files <- paste0(fs::path_ext_remove(output), "_files")
   files <- trn(all(file.exists(files)), files, character(0))
-  c(output, files, source)
+  c(output, source, files)
 }

--- a/R/tar_render_rep.R
+++ b/R/tar_render_rep.R
@@ -23,8 +23,8 @@
 #'       watches the files at the returned paths and reruns the report
 #'       if those files change.
 #'     3. Configures the target's command to return the output
-#'       report files, including the `*_files/` directory if it exists,
-#'       and the input source file. All these file paths
+#'       report files: the rendered document, the source file,
+#'       and then the `*_files/` directory if it exists. All these file paths
 #'       are relative paths so the project stays portable.
 #'     4. Forces the report to run in the user's current working directory
 #'       instead of the working directory of the report.

--- a/R/tar_render_rep.R
+++ b/R/tar_render_rep.R
@@ -22,8 +22,9 @@
 #'     2. Sets `format = "file"` (see `tar_target()`) so `targets`
 #'       watches the files at the returned paths and reruns the report
 #'       if those files change.
-#'     3. Configures the target's command to return both the output
-#'       report files and the input source file. All these file paths
+#'     3. Configures the target's command to return the output
+#'       report files, including the `*_files/` directory if it exists,
+#'       and the input source file. All these file paths
 #'       are relative paths so the project stays portable.
 #'     4. Forces the report to run in the user's current working directory
 #'       instead of the working directory of the report.

--- a/R/tar_render_rep_raw.R
+++ b/R/tar_render_rep_raw.R
@@ -27,8 +27,9 @@
 #'       watches the files at the returned paths and reruns the report
 #'       if those files change.
 #'     3. Configures the target's command to return the output
-#'       report files, the `*_files/` directories with supporting files
-#'       if they exist, and the input source file. All these file paths
+#'       report files: the rendered document, the source file,
+#'       and then the `*_files/` directory if it exists.
+#'       All these file paths
 #'       are relative paths so the project stays portable.
 #'     4. Forces the report to run in the user's current working directory
 #'       instead of the working directory of the report.

--- a/R/tar_render_rep_raw.R
+++ b/R/tar_render_rep_raw.R
@@ -26,8 +26,9 @@
 #'     2. Sets `format = "file"` (see `tar_target()`) so `targets`
 #'       watches the files at the returned paths and reruns the report
 #'       if those files change.
-#'     3. Configures the target's command to return both the output
-#'       report files and the input source file. All these file paths
+#'     3. Configures the target's command to return the output
+#'       report files, the `*_files/` directories with supporting files
+#'       if they exist, and the input source file. All these file paths
 #'       are relative paths so the project stays portable.
 #'     4. Forces the report to run in the user's current working directory
 #'       instead of the working directory of the report.
@@ -216,7 +217,8 @@ tar_render_rep_rep <- function(path, params, args) {
   args$params <- params
   args$params[["output_file"]] <- NULL
   args$params[["tar_group"]] <- NULL
-  fs::path_rel(c(do.call(rmarkdown::render, args), path))
+  output <- do.call(rmarkdown::render, args)
+  tar_render_paths(output, path)
 }
 
 tar_render_rep_default_path <- function(path, params) {

--- a/man/tar_change.Rd
+++ b/man/tar_change.Rd
@@ -172,7 +172,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_combine.Rd
+++ b/man/tar_combine.Rd
@@ -181,7 +181,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_combine_raw.Rd
+++ b/man/tar_combine_raw.Rd
@@ -181,7 +181,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_files.Rd
+++ b/man/tar_files.Rd
@@ -105,7 +105,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_files_input.Rd
+++ b/man/tar_files_input.Rd
@@ -80,7 +80,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_files_input_raw.Rd
+++ b/man/tar_files_input_raw.Rd
@@ -80,7 +80,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_files_raw.Rd
+++ b/man/tar_files_raw.Rd
@@ -99,7 +99,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_force.Rd
+++ b/man/tar_force.Rd
@@ -173,7 +173,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_formats.Rd
+++ b/man/tar_formats.Rd
@@ -248,7 +248,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_knit.Rd
+++ b/man/tar_knit.Rd
@@ -62,7 +62,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_knit_raw.Rd
+++ b/man/tar_knit_raw.Rd
@@ -56,7 +56,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_render.Rd
+++ b/man/tar_render.Rd
@@ -103,10 +103,9 @@ See the examples section for a demonstration.}
 \value{
 A target object with \code{format = "file"}.
 When this target runs, it returns a character vector
-of file paths. The first file paths are the output files
-(returned by \code{rmarkdown::render()}), including the \verb{*_files/}
-directory with supporting files if it exists, and the R Markdown
-source file is last. Unlike \code{rmarkdown::render()},
+of file paths: the rendered document, the source file,
+and then the \verb{*_files/} directory if it exists.
+Unlike \code{rmarkdown::render()},
 all returned paths are \emph{relative} paths to ensure portability
 (so that the project can be moved from one file system to another
 without invalidating the target).

--- a/man/tar_render.Rd
+++ b/man/tar_render.Rd
@@ -62,7 +62,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if
@@ -101,8 +104,9 @@ See the examples section for a demonstration.}
 A target object with \code{format = "file"}.
 When this target runs, it returns a character vector
 of file paths. The first file paths are the output files
-(returned by \code{rmarkdown::render()}) and the R Markdown
-source file is last. But unlike \code{rmarkdown::render()},
+(returned by \code{rmarkdown::render()}), including the \verb{*_files/}
+directory with supporting files if it exists, and the R Markdown
+source file is last. Unlike \code{rmarkdown::render()},
 all returned paths are \emph{relative} paths to ensure portability
 (so that the project can be moved from one file system to another
 without invalidating the target).

--- a/man/tar_render_raw.Rd
+++ b/man/tar_render_raw.Rd
@@ -95,10 +95,9 @@ all non-standard evaluation.}
 \value{
 A target object with \code{format = "file"}.
 When this target runs, it returns a character vector
-of file paths. The first file paths are the output files
-(returned by \code{rmarkdown::render()}), including
-the \verb{*_files/} directory with supporting files if it exists,
-and the R Markdown source file is last. Unlike \code{rmarkdown::render()},
+of file paths: the rendered document, the source file,
+and then the \verb{*_files/} directory if it exists.
+Unlike \code{rmarkdown::render()},
 all returned paths are \emph{relative} paths to ensure portability
 (so that the project can be moved from one file system to another
 without invalidating the target).

--- a/man/tar_render_raw.Rd
+++ b/man/tar_render_raw.Rd
@@ -56,7 +56,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if
@@ -93,8 +96,9 @@ all non-standard evaluation.}
 A target object with \code{format = "file"}.
 When this target runs, it returns a character vector
 of file paths. The first file paths are the output files
-(returned by \code{rmarkdown::render()}) and the R Markdown
-source file is last. But unlike \code{rmarkdown::render()},
+(returned by \code{rmarkdown::render()}), including
+the \verb{*_files/} directory with supporting files if it exists,
+and the R Markdown source file is last. Unlike \code{rmarkdown::render()},
 all returned paths are \emph{relative} paths to ensure portability
 (so that the project can be moved from one file system to another
 without invalidating the target).

--- a/man/tar_render_rep.Rd
+++ b/man/tar_render_rep.Rd
@@ -155,7 +155,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if
@@ -220,8 +223,9 @@ This enforces the proper dependency relationships.
 2. Sets \code{format = "file"} (see \code{tar_target()}) so \code{targets}
 watches the files at the returned paths and reruns the report
 if those files change.
-3. Configures the target's command to return both the output
-report files and the input source file. All these file paths
+3. Configures the target's command to return the output
+report files, including the \verb{*_files/} directory if it exists,
+and the input source file. All these file paths
 are relative paths so the project stays portable.
 4. Forces the report to run in the user's current working directory
 instead of the working directory of the report.

--- a/man/tar_render_rep.Rd
+++ b/man/tar_render_rep.Rd
@@ -224,8 +224,8 @@ This enforces the proper dependency relationships.
 watches the files at the returned paths and reruns the report
 if those files change.
 3. Configures the target's command to return the output
-report files, including the \verb{*_files/} directory if it exists,
-and the input source file. All these file paths
+report files: the rendered document, the source file,
+and then the \verb{*_files/} directory if it exists. All these file paths
 are relative paths so the project stays portable.
 4. Forces the report to run in the user's current working directory
 instead of the working directory of the report.

--- a/man/tar_render_rep_raw.Rd
+++ b/man/tar_render_rep_raw.Rd
@@ -150,8 +150,9 @@ This enforces the proper dependency relationships.
 watches the files at the returned paths and reruns the report
 if those files change.
 3. Configures the target's command to return the output
-report files, the \verb{*_files/} directories with supporting files
-if they exist, and the input source file. All these file paths
+report files: the rendered document, the source file,
+and then the \verb{*_files/} directory if it exists.
+All these file paths
 are relative paths so the project stays portable.
 4. Forces the report to run in the user's current working directory
 instead of the working directory of the report.

--- a/man/tar_render_rep_raw.Rd
+++ b/man/tar_render_rep_raw.Rd
@@ -79,7 +79,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if
@@ -146,8 +149,9 @@ This enforces the proper dependency relationships.
 2. Sets \code{format = "file"} (see \code{tar_target()}) so \code{targets}
 watches the files at the returned paths and reruns the report
 if those files change.
-3. Configures the target's command to return both the output
-report files and the input source file. All these file paths
+3. Configures the target's command to return the output
+report files, the \verb{*_files/} directories with supporting files
+if they exist, and the input source file. All these file paths
 are relative paths so the project stays portable.
 4. Forces the report to run in the user's current working directory
 instead of the working directory of the report.

--- a/man/tar_rep.Rd
+++ b/man/tar_rep.Rd
@@ -184,7 +184,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_rep_raw.Rd
+++ b/man/tar_rep_raw.Rd
@@ -179,7 +179,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/man/tar_skip.Rd
+++ b/man/tar_skip.Rd
@@ -173,7 +173,10 @@ a drop-in replacement for \code{\link[targets:tar_make]{tar_make()}} in this cas
 \item Custom target-level \code{future::plan()}, e.g.
 \code{resources = list(plan = future.callr::callr)}.
 \item Custom \code{curl} handle if \code{format = "url"},
-e.g. \code{resources = list(handle = curl::new_handle())}.
+e.g. \code{resources = list(handle = curl::new_handle(nobody = TRUE))}.
+In custom handles, most users should manually set \code{nobody = TRUE}
+so \code{targets} does not download the entire file when it
+only needs to check the time stamp and ETag.
 \item Custom preset for \code{qs::qsave()} if \code{format = "qs"}, e.g.
 \code{resources = list(handle = "archive")}.
 \item Custom compression level for \code{fst::write_fst()} if

--- a/tests/testthat/test-tar_render.R
+++ b/tests/testthat/test-tar_render.R
@@ -97,3 +97,27 @@ targets::tar_test("tar_render() for parameterized reports", {
   lines <- readLines("report.html")
   expect_true(any(grepl("anotherverydistinctvalue", lines)))
 })
+
+targets::tar_test("tar_render() with a _files/ directory", {
+  skip_pandoc()
+  lines <- c(
+    "---",
+    "title: report with a plot",
+    "output_format: html_document",
+    "---",
+    "```{r}",
+    "plot(seq_len(4))",
+    "```"
+  )
+  writeLines(lines, "report.Rmd")
+  targets::tar_script({
+    library(tarchetypes)
+    list(tar_render(report, "report.Rmd", clean = FALSE))
+  })
+  suppressMessages(targets::tar_make(callr_function = NULL))
+  expect_equal(
+    basename(targets::tar_read(report)),
+    c("report.html", "report.Rmd", "report_files")
+  )
+})
+

--- a/tests/testthat/test-tar_render.R
+++ b/tests/testthat/test-tar_render.R
@@ -120,4 +120,3 @@ targets::tar_test("tar_render() with a _files/ directory", {
     c("report.html", "report.Rmd", "report_files")
   )
 })
-

--- a/tests/testthat/test-tar_render_rep.R
+++ b/tests/testthat/test-tar_render_rep.R
@@ -10,7 +10,7 @@ targets::tar_test("tar_render_rep() manifest", {
     "",
     "```{r}",
     "print(params$par)",
-    "print(tar_read(x))",
+    "print(targets::tar_read(x))",
     "```"
   )
   writeLines(lines, "report.Rmd")
@@ -48,7 +48,7 @@ targets::tar_test("tar_render_rep() graph", {
     "",
     "```{r}",
     "print(params$par)",
-    "print(tar_read(x))",
+    "print(targets::tar_read(x))",
     "```"
   )
   writeLines(lines, "report.Rmd")
@@ -85,7 +85,7 @@ targets::tar_test("tar_render_rep() run", {
     "",
     "```{r}",
     "print(params$par)",
-    "print(tar_read(x))",
+    "print(targets::tar_read(x))",
     "```"
   )
   writeLines(lines, "report.Rmd")
@@ -192,7 +192,7 @@ targets::tar_test("tar_render_rep() run with output_file specified", {
     "",
     "```{r}",
     "print(params$par)",
-    "print(tar_read(x))",
+    "print(targets::tar_read(x))",
     "```"
   )
   writeLines(lines, "report.Rmd")
@@ -217,4 +217,47 @@ targets::tar_test("tar_render_rep() run with output_file specified", {
   out <- unlist(targets::tar_meta(report, children)$children)
   expect_equal(length(out), 4L)
   expect_equal(length(unique(out)), 4L)
+})
+
+targets::tar_test("tar_render_rep() with output_file and _files", {
+  skip_pandoc()
+  lines <- c(
+    "---",
+    "title: report",
+    "output_format: html_document",
+    "params:",
+    "  par: \"default value\"",
+    "---",
+    "",
+    "```{r}",
+    "print(params$par)",
+    "print(targets::tar_read(x))",
+    "plot(sample.int(1e9, 4))",
+    "```"
+  )
+  writeLines(lines, "report.Rmd")
+  targets::tar_script({
+    library(tarchetypes)
+    list(
+      tar_target(x, "value_of_x"),
+      tar_render_rep(
+        report,
+        "report.Rmd",
+        params = data.frame(
+          par = c("parval1", "parval2", "parval3", "parval4"),
+          output_file = c("f1.html", "f2.html", "f3.html", "f4.html"),
+          stringsAsFactors = FALSE
+        ),
+        clean = FALSE
+      )
+    )
+  })
+  targets::tar_make(callr_function = NULL)
+  for (branch in seq_len(4)) {
+    out <- targets::tar_read_raw("report", branches = branch)
+    base <- paste0("f", branch)
+    report <- fs::path_ext_set(base, "html")
+    exp <- c(report, "report.Rmd", paste0(base, "_files"))
+    expect_equal(out, exp)
+  }
 })

--- a/tests/testthat/test-tar_render_rep.R
+++ b/tests/testthat/test-tar_render_rep.R
@@ -254,7 +254,7 @@ targets::tar_test("tar_render_rep() with output_file and _files", {
   })
   targets::tar_make(callr_function = NULL)
   for (branch in seq_len(4)) {
-    out <- targets::tar_read_raw("report", branches = branch)
+    out <- basename(targets::tar_read_raw("report", branches = branch))
     base <- paste0("f", branch)
     report <- fs::path_ext_set(base, "html")
     exp <- c(report, "report.Rmd", paste0(base, "_files"))


### PR DESCRIPTION
# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci/tarchetypes/blob/main/CONTRIBUTING.md).
* [x] I have already submitted an [issue](http://github.com/ropensci/tarchetypes/issues) or [discussion thread](https://github.com/ropensci/tarchetypes/discussions) to discuss my idea with the maintainer.
* [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).

# Related GitHub issues and pull requests

* Ref: 30#

# Summary

Many R Markdown reports are not self-contained and rely on a `*_files/` directory of supporting files. These files should be reproducibly tracked along with the HTML output. This comes up a lot for downstream targets that call `rsconnect::deployApp()`. Currently, these deploy targets do not always automatically rerun if the figures in the report change but not the HTML itself.