### PR TITLE
tar_render fails with (child) documents in a subdir

### DIFF
--- a/R/utils_knitr.R
+++ b/R/utils_knitr.R
@@ -34,7 +34,15 @@ knitr_lines <- function(path) {
   handle <- basename(tempfile())
   connection <- textConnection(handle, open = "w", local = TRUE)
   on.exit(close(connection))
+
+  # Setting the knitr working directory to our project (targets) directory.
+  # Otherwise, the directory of `path` is used and we cannot open a connection
+  # to child documents.
+  # See https://github.com/ropensci/tarchetypes/pull/93 for a discussion.
+  old_root_dir <- knitr::opts_knit$get("root.dir")
   knitr::opts_knit$set(root.dir = getwd())
+  on.exit(knitr::opts_knit$set(root.dir = old_root_dir), add = TRUE)
+
   withr::with_options(
     new = list(knitr.purl.inline = TRUE),
     code = knitr::knit(path, output = connection, tangle = TRUE, quiet = TRUE)

--- a/R/utils_knitr.R
+++ b/R/utils_knitr.R
@@ -34,6 +34,7 @@ knitr_lines <- function(path) {
   handle <- basename(tempfile())
   connection <- textConnection(handle, open = "w", local = TRUE)
   on.exit(close(connection))
+  knitr::opts_knit$set(root.dir = getwd())
   withr::with_options(
     new = list(knitr.purl.inline = TRUE),
     code = knitr::knit(path, output = connection, tangle = TRUE, quiet = TRUE)

--- a/tests/testthat/test-tar_render.R
+++ b/tests/testthat/test-tar_render.R
@@ -138,6 +138,10 @@ targets::tar_test("tar_render() works with child documents", {
       "---",
       "",
       "```{r, child = \"report/child.Rmd\"}",
+      "```",
+      "",
+      "```{r}",
+      "targets::tar_read(main)",
       "```"
     ),
     con = "report/main.Rmd"
@@ -147,16 +151,18 @@ targets::tar_test("tar_render() works with child documents", {
       "# Child Document",
       "",
       "```{r}",
-      "targets::tar_read(data)",
+      "targets::tar_read(child)",
       "```"
     ),
     con = "report/child.Rmd"
   )
 
   targets::tar_script({
+    library(targets)
     library(tarchetypes)
     list(
-      tar_target(data, data.frame(x = seq_len(26L), y = letters)),
+      tar_target(main, "value_main_target"),
+      tar_target(child, "value_child_target"),
       tar_render(report, "report/main.Rmd", quiet = TRUE)
     )
   })
@@ -165,7 +171,7 @@ targets::tar_test("tar_render() works with child documents", {
   suppressMessages(targets::tar_make(callr_function = NULL))
   progress <- targets::tar_progress()
   progress <- progress[progress$progress != "skipped", ]
-  expect_equal(sort(progress$name), sort(c("data", "report")))
+  expect_equal(sort(progress$name), sort(c("child", "main", "report")))
   out <- targets::tar_read(report)
   expect_equal(out, c("report/main.html", "report/main.Rmd"))
 
@@ -174,16 +180,104 @@ targets::tar_test("tar_render() works with child documents", {
   progress <- targets::tar_progress()
   progress <- progress[progress$progress != "skipped", ]
   expect_equal(nrow(progress), 0L)
-  targets::tar_script({
-    library(tarchetypes)
-    list(
-      tar_target(data, data.frame(x = rev(seq_len(26L)), y = letters)),
-      tar_render(report, "report/main.Rmd")
-    )
-  })
 
   # Should rerun the report.
+  # Only the dependency in the main document is changed.
+  targets::tar_script({
+    library(targets)
+    library(tarchetypes)
+    list(
+      tar_target(main, "value_main_target_changed"),
+      tar_target(child, "value_child_target"),
+      tar_render(report, "report/main.Rmd", quiet = TRUE)
+    )
+  })
   suppressMessages(targets::tar_make(callr_function = NULL))
-  expect_equal(sort(targets::tar_progress()$name), sort(c("data", "report")))
-})
+  expect_equal(
+    sort(targets::tar_progress()$name),
+    sort(c("child", "main", "report"))
+  )
 
+  # Should rerun the report.
+  # Only the dependency in the child document is changed.
+  targets::tar_script({
+    library(targets)
+    library(tarchetypes)
+    list(
+      tar_target(main, "value_main_target_changed"),
+      tar_target(child, "value_child_target_changed"),
+      tar_render(report, "report/main.Rmd", quiet = TRUE)
+    )
+  })
+  suppressMessages(targets::tar_make(callr_function = NULL))
+  expect_equal(
+    sort(targets::tar_progress()$name),
+    sort(c("child", "main", "report"))
+  )
+
+  # Should rerun the report.
+  # Change the main file slightly (but not the code)
+  writeLines(
+    text = c(
+      "---",
+      "title: A new report",
+      "output_format: html_document",
+      "---",
+      "",
+      "```{r, child = \"report/child.Rmd\"}",
+      "```",
+      "",
+      "```{r}",
+      "targets::tar_read(main)",
+      "```"
+    ),
+    con = "report/main.Rmd"
+  )
+  suppressMessages(targets::tar_make(callr_function = NULL))
+  expect_equal(
+    sort(targets::tar_progress()$name),
+    sort(c("child", "main", "report"))
+  )
+
+  # Should rerun the report.
+  # Change the child file slightly (but not the code)
+  writeLines(
+    text = c(
+      "# A New Child Document",
+      "",
+      "```{r}",
+      "targets::tar_read(child)",
+      "```"
+    ),
+    con = "report/child.Rmd"
+  )
+  suppressMessages(targets::tar_make(callr_function = NULL))
+  expect_equal(
+    sort(targets::tar_progress()$name),
+    sort(c("child", "main", "report"))
+  )
+
+  # Detect whether `value_main_target_changed` and
+  # `value_child_target_changed` are correctly print in HTML file
+  # (the values should occure once in the HTML file)
+  html_file <- readLines("report/main.html")
+  expect_identical(
+    sum(grepl("value_main_target_changed", html_file, fixed = TRUE)),
+    1L
+  )
+  expect_identical(
+    sum(grepl("value_child_target_changed", html_file, fixed = TRUE)),
+    1L
+  )
+
+  # Check that the dependency graph is correct of our targets. `report` should
+  # depend on `main` and `child`.
+  edges <- tar_network(callr_function = NULL)$edges
+  expect_identical(
+    edges,
+    tibble::tibble(
+      from = c("child", "main"),
+      to = c("report", "report")
+    )
+  )
+})


### PR DESCRIPTION
# Prework

* [X] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [X] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci/tarchetypes/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted an [issue](http://github.com/ropensci/tarchetypes/issues) or [discussion thread](https://github.com/ropensci/tarchetypes/discussions) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: TBD

# Summary

Many thanks for your work on the targets/tarchetypes libraries. I discovered them recently and it makes my analysis much cleaner!

I'm sorry for not open an issue earlier. If you prefer to move the discussion to an issue, I'm happy to open one.

## Problem statement

I often use the following directory structure:

```
- _targets.R
- R/
- report/
  - report/main.Rmd
  - report/child.Rmd
```

In my `_targets.R` file, I call `tar_render(report, "report/main.Rmd")`. In `main.Rmd` a child document is included `child.Rmd`, using the chunk option `child = "child.Rmd"`.

[Starting from knitr 1.37](https://github.com/yihui/knitr/releases/tag/v1.37), knitr adds the `root.dir` option in front of the `child` chunk option. Tarchetypes sets the `root.dir` to the current working directory (using `knit_root_dir` of rmarkdown), thus the `root.dir` is in my project directory and not in the `report` directory. Accordingly, knitr expects an inclusion with `child = "report/child.Rmd"`. However, the dependency detection does not yet set the working directory to the project directory but to the `report` directory. This PR fixes this.

Without this patch, the report generation fails with:

```
Quitting from lines 36-36 (./report/report/child.Rmd)
Error in targets::tar_throw_validate("Could not parse knitr report ",  :
  Could not parse knitr report ./report/main.Rmd to detect dependencies: cannot open the connection
In addition: Warning message:
In file(con, "r") :
  cannot open file './report/report/child.Rmd': No such file or directory
```


## Possible Drawbacks

Users have to change their child chunk option to include the subdir path. This might not be desired by some users. It is also possible to set the working directory (`knit_root_dir`) of the render command to the `report` directory (in my example). However, this results in errors using `tar_read`. This commands expects a `_targets/` which is in the parent directory and not in the `report` directory. In my opinion, this is a greater disadvantage.


## Alternative Implementations

I'm happy to change to change the code after your feedback.