### PR TITLE
Remove duplicate `@inheritSection` tag from tar_map_rep and tar_map_rep_raw

### DIFF
--- a/R/tar_map_rep.R
+++ b/R/tar_map_rep.R
@@ -17,7 +17,6 @@
 #'   are not appended.
 #' @param combine Logical of length 1, whether to statically combine
 #'   all the results into a single target downstream.
-#' @inheritSection tar_map Target objects
 #' @examples
 #' if (identical(Sys.getenv("TAR_LONG_EXAMPLES"), "true")) {
 #' targets::tar_dir({ # tar_dir() runs code from a temporary directory.

--- a/R/tar_map_rep_raw.R
+++ b/R/tar_map_rep_raw.R
@@ -29,7 +29,6 @@
 #'   but the default is `"rds"` to avoid incurring extra package
 #'   dependencies. See the help file of `targets::tar_target()`
 #'   for details on storage formats.
-#' @inheritSection tar_map Target objects
 #' @inheritParams targets::tar_target
 #' @inheritParams tar_map
 #' @inheritParams tar_rep

--- a/man/tar_map_rep.Rd
+++ b/man/tar_map_rep.Rd
@@ -253,23 +253,6 @@ explains target factories (functions like this one which generate targets)
 and the design specification at
 \url{https://books.ropensci.org/targets-design/}
 details the structure and composition of target objects.
-
-
-Most \code{tarchetypes} functions are target factories,
-which means they return target objects
-or lists of target objects.
-Target objects represent skippable steps of the analysis pipeline
-as described at \url{https://books.ropensci.org/targets/}.
-Please read the walkthrough at
-\url{https://books.ropensci.org/targets/walkthrough.html}
-to understand the role of target objects in analysis pipelines.
-
-For developers,
-\url{https://wlandau.github.io/targetopia/contributing.html#target-factories}
-explains target factories (functions like this one which generate targets)
-and the design specification at
-\url{https://books.ropensci.org/targets-design/}
-details the structure and composition of target objects.
 }
 
 \section{Replicate-specific seeds}{

--- a/man/tar_map_rep_raw.Rd
+++ b/man/tar_map_rep_raw.Rd
@@ -258,23 +258,6 @@ explains target factories (functions like this one which generate targets)
 and the design specification at
 \url{https://books.ropensci.org/targets-design/}
 details the structure and composition of target objects.
-
-
-Most \code{tarchetypes} functions are target factories,
-which means they return target objects
-or lists of target objects.
-Target objects represent skippable steps of the analysis pipeline
-as described at \url{https://books.ropensci.org/targets/}.
-Please read the walkthrough at
-\url{https://books.ropensci.org/targets/walkthrough.html}
-to understand the role of target objects in analysis pipelines.
-
-For developers,
-\url{https://wlandau.github.io/targetopia/contributing.html#target-factories}
-explains target factories (functions like this one which generate targets)
-and the design specification at
-\url{https://books.ropensci.org/targets-design/}
-details the structure and composition of target objects.
 }
 
 \section{Replicate-specific seeds}{


### PR DESCRIPTION
# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci/tarchetypes/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted an [issue](http://github.com/ropensci/tarchetypes/issues) or [discussion thread](https://github.com/ropensci/tarchetypes/discussions) to discuss my idea with the maintainer. (Sorry -- I didn't see the right issue template for bugs, and figured it'd be just as fast to send a PR given I'm _pretty_ sure this is unintentional)

# Summary

The `Target objects` section from tar_map was inherited twice in both tar_map_rep and tar_map_rep_raw, causing the relevant section to be duplicated in help pages and on pkgdown:

https://docs.ropensci.org/tarchetypes/reference/tar_map_rep.html
![image](https://user-images.githubusercontent.com/38229299/235762664-d78b8ea8-1e22-4a8c-8d54-c1dfb73f8ac3.png)

This PR removes the second `@inheritSection` in each file and re-documents the package. I checked via `grep` to confirm these are the only files with duplicated `@inheritSection` tags.