### PR TITLE
fix(render): Rerender also when child files changes

### DIFF
--- a/tests/testthat/test-tar_render.R
+++ b/tests/testthat/test-tar_render.R
@@ -172,9 +172,12 @@ targets::tar_test("tar_render() works with child documents", {
   expect_equal(sort(progress$name), sort(c("child", "main", "report")))
   out <- targets::tar_read(report)
   if (identical(tolower(Sys.info()[["sysname"]]), "windows")) {
-    expect_equal(basename(out), c("main.html", "main.Rmd"))
+    expect_equal(basename(out), c("main.html", "main.Rmd", "child.Rmd"))
   } else {
-    expect_equal(out, c("report/main.html", "report/main.Rmd"))
+    expect_equal(
+      out,
+      c("report/main.html", "report/main.Rmd", "report/child.Rmd")
+    )
   }
   # Should not rerun the report.
   suppressMessages(targets::tar_make(callr_function = NULL))
@@ -194,8 +197,11 @@ targets::tar_test("tar_render() works with child documents", {
   })
   suppressMessages(targets::tar_make(callr_function = NULL))
   expect_equal(
-    sort(targets::tar_progress()$name),
-    sort(c("child", "main", "report"))
+    targets::tar_progress(),
+    tibble::tibble(
+      name = c("child", "main", "report"),
+      progress = c("skipped", "built", "built")
+    )
   )
   # Should rerun the report.
   # Only the dependency in the child document is changed.
@@ -210,8 +216,11 @@ targets::tar_test("tar_render() works with child documents", {
   })
   suppressMessages(targets::tar_make(callr_function = NULL))
   expect_equal(
-    sort(targets::tar_progress()$name),
-    sort(c("child", "main", "report"))
+    targets::tar_progress(),
+    tibble::tibble(
+      name = c("child", "main", "report"),
+      progress = c("built", "skipped", "built")
+    )
   )
   # Should rerun the report.
   # Change the main file slightly (but not the code)
@@ -233,8 +242,11 @@ targets::tar_test("tar_render() works with child documents", {
   )
   suppressMessages(targets::tar_make(callr_function = NULL))
   expect_equal(
-    sort(targets::tar_progress()$name),
-    sort(c("child", "main", "report"))
+    targets::tar_progress(),
+    tibble::tibble(
+      name = c("child", "main", "report"),
+      progress = c("skipped", "skipped", "built")
+    )
   )
   # Should rerun the report.
   # Change the child file slightly (but not the code)
@@ -250,8 +262,11 @@ targets::tar_test("tar_render() works with child documents", {
   )
   suppressMessages(targets::tar_make(callr_function = NULL))
   expect_equal(
-    sort(targets::tar_progress()$name),
-    sort(c("child", "main", "report"))
+    targets::tar_progress(),
+    tibble::tibble(
+      name = c("child", "main", "report"),
+      progress = c("skipped", "skipped", "built")
+    )
   )
   # Detect whether `value_main_target_changed` and
   # `value_child_target_changed` are correctly print in HTML file


### PR DESCRIPTION
# Prework

* [X] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [X] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci/tarchetypes/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted an [issue](http://github.com/ropensci/tarchetypes/issues) or [discussion thread](https://github.com/ropensci/tarchetypes/discussions) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: None so far.

# Summary

Please explain the purpose and scope of your contribution.

Currently, a knitr/rmarkdown report is only rerun if a) dependent targets change, b) output files in the e.g. `main_files` directory (created by knitr if the output file is called `main`), or c) the main (source) file of the report changes. However, if the text of a child document changes, a rerun is also desired.

Thus, the current commit adds the child files of a report to the return value and thus, checking these files for changes.


# Remarks

- Sorry for not opening an issue earlier. I hope we can discuss the problem here as well.
- The added code does not look very pretty. It could be simplified using the `stringr` package but I didn't want to add an extra dependency for such a small change. I also used the `|>` and `\(x)` operators here. I don't mind to change these if you don't like them. I'm also happy about any changes and improvements you propose.
- With the current approach, the report is rendered twice by `knitr_lines` what is probably not desired. However, I think the current changes were the simplest one even though an overhead is added.
- In the tests, the `sort` function is missing now. However, I had no issues even without sorting. Do you think an ordered tibble is necessary?
- In `tar_render_paths` the return files are sorted, `output` and `source` as well. However `output` and `source` should be of length 1. Thus, is it safe to omit the `sort` function?
- I hope you had a good vacation :) 

Thanks for your feedback!