### PR TITLE
allows use of = for assignment in tar_assign

### DIFF
--- a/R/tar_assign.R
+++ b/R/tar_assign.R
@@ -14,9 +14,9 @@
 #'   are as follows:
 #'   * The code supplied to [tar_assign()] must be enclosed in curly braces
 #'     beginning with `{` and `}` unless it only contains a
-#'     one-line statement.
+#'     one-line statement or uses `=` as the assignment.
 #'   * Each statement in the code block must be of the form
-#'     `x <- f()`, where `x` is the name of a target and
+#'     `x <- f()`, or `x = f()` where `x` is the name of a target and
 #'     `f()` is a function like `tar_target()` or [tar_quarto()]
 #'     which accepts a `name` argument.
 #'   * The native pipe operator `|>` is allowed because it lazily
@@ -36,7 +36,7 @@
 #'       filter(!is.na(Ozone)) |>
 #'       tar_target()
 #'
-#'     model <- lm(Ozone ~ Temp, data) |>
+#'     model = lm(Ozone ~ Temp, data) |>
 #'       coefficients() |>
 #'       tar_target()
 #'
@@ -59,12 +59,16 @@ tar_assign <- function(targets) {
     as.list(expr[-1L]),
     list(expr)
   )
+  check_assign <- function(x){
+    identical(x[[1L]], quote(`<-`)) || identical(x[[1L]], quote(`=`))
+  }
   targets::tar_assert_true(
-    all(map_lgl(statements, ~identical(.x[[1L]], quote(`<-`)))),
+    all(map_lgl(statements, check_assign)),
     msg = paste(
       "tar_assign() code must be enclosed in curly braces if",
       "it has multiple statements, and each statement",
-      "must be an assignment statement using the left arrow <-"
+      "must be an assignment statement using the left arrow <-",
+      "or equal sign ="
     )
   )
   envir <- targets::tar_option_get("envir")

--- a/man/tar_assign.Rd
+++ b/man/tar_assign.Rd
@@ -16,9 +16,9 @@ are as follows:
 \itemize{
 \item The code supplied to \code{\link[=tar_assign]{tar_assign()}} must be enclosed in curly braces
 beginning with \verb{\{} and \verb{\}} unless it only contains a
-one-line statement.
+one-line statement or uses \code{=} as the assignment.
 \item Each statement in the code block must be of the form
-\code{x <- f()}, where \code{x} is the name of a target and
+\code{x <- f()}, or \code{x = f()} where \code{x} is the name of a target and
 \code{f()} is a function like \code{tar_target()} or \code{\link[=tar_quarto]{tar_quarto()}}
 which accepts a \code{name} argument.
 \item The native pipe operator \verb{|>} is allowed because it lazily
@@ -67,7 +67,7 @@ targets::tar_script({
       filter(!is.na(Ozone)) |>
       tar_target()
 
-    model <- lm(Ozone ~ Temp, data) |>
+    model = lm(Ozone ~ Temp, data) |>
       coefficients() |>
       tar_target()
 

--- a/tests/testthat/test-tar_assign.R
+++ b/tests/testthat/test-tar_assign.R
@@ -5,12 +5,19 @@ targets::tar_test("tar_assign() single statement", {
   expect_equal(out$command, "c(1L, 2L)")
   targets::tar_make(callr_function = NULL)
   expect_equal(targets::tar_read(x), c(1L, 2L))
+  
+  targets::tar_script(tar_assign({x = tar_target(c(1L, 2L))}))
+  out <- targets::tar_manifest(callr_function = NULL)
+  expect_equal(out$name, "x")
+  expect_equal(out$command, "c(1L, 2L)")
+  targets::tar_make(callr_function = NULL)
+  expect_equal(targets::tar_read(x), c(1L, 2L))
 })
 
 targets::tar_test("tar_assign()", {
   targets::tar_script({
     tar_assign({
-      x <- tar_target(c(1L, 2L))
+      x = tar_target(c(1L, 2L))
       y <- tar_target(x + 1L, pattern = map(x))
       z <- tar_rep(TRUE, batches = 2L)
     })


### PR DESCRIPTION
# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci/tarchetypes/blob/main/CONTRIBUTING.md).
* [x] I have already submitted an [issue](http://github.com/ropensci/tarchetypes/issues) or [discussion thread](https://github.com/ropensci/tarchetypes/discussions) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #188 

# Summary

Adds one more function in `tar_assign` to check that the first part of the statement is either `<-` or `=`, and modifies the documentation slightly, as well as the tests to check for this.
