### PR TITLE
feat(quarto): add output file argument

### DIFF
--- a/R/tar_quarto.R
+++ b/R/tar_quarto.R
@@ -141,6 +141,7 @@
 tar_quarto <- function(
   name,
   path = ".",
+  output_file = NULL,
   working_directory = NULL,
   extra_files = character(0),
   execute = TRUE,
@@ -174,6 +175,7 @@ tar_quarto <- function(
   tar_quarto_raw(
     name = name,
     path = path,
+    output_file = output_file,
     working_directory = working_directory,
     extra_files = extra_files,
     execute = execute,

--- a/R/tar_quarto_raw.R
+++ b/R/tar_quarto_raw.R
@@ -3,6 +3,7 @@
 tar_quarto_raw <- function(
   name,
   path = ".",
+  output_file = NULL,
   working_directory = NULL,
   extra_files = character(0),
   execute = TRUE,
@@ -33,6 +34,10 @@ tar_quarto_raw <- function(
   targets::tar_assert_chr(extra_files)
   targets::tar_assert_nzchar(extra_files)
   targets::tar_assert_file(path)
+  if (!is.null(output_file)) {
+    targets::tar_assert_chr(output_file)
+    targets::tar_assert_nzchar(output_file)
+  }
   if (!is.null(working_directory)) {
     targets::tar_assert_file(working_directory)
   }
@@ -56,6 +61,9 @@ tar_quarto_raw <- function(
   info <- tar_quarto_files(path = path, profile = profile)
   sources <- info$sources
   output <- info$output
+  if (!is.null(output_file)) {
+    output <- file.path(dirname(output), output_file)
+  }
   input <- sort(unique(c(info$input, extra_files)))
   if (!is.null(packages) || !is.null(library)) {
     targets::tar_warn_deprecate(
@@ -66,6 +74,7 @@ tar_quarto_raw <- function(
   }
   command <- tar_quarto_command(
     path = path,
+    output_file = output_file,
     working_directory = working_directory,
     sources = sources,
     output = output,
@@ -99,6 +108,7 @@ tar_quarto_raw <- function(
 
 tar_quarto_command <- function(
   path,
+  output_file,
   working_directory,
   sources,
   output,
@@ -116,6 +126,7 @@ tar_quarto_command <- function(
   args <- substitute(
     list(
       input = path,
+      output_file = output_file,
       execute = execute,
       execute_params = execute_params,
       execute_dir = execute_dir,
@@ -132,6 +143,7 @@ tar_quarto_command <- function(
     ),
     env = list(
       path = path,
+      output_file = output_file,
       execute = execute,
       execute_dir = working_directory %|||% quote(getwd()),
       execute_params = execute_params,

--- a/man/tar_quarto.Rd
+++ b/man/tar_quarto.Rd
@@ -8,6 +8,7 @@
 tar_quarto(
   name,
   path = ".",
+  output_file = NULL,
   working_directory = NULL,
   extra_files = character(0),
   execute = TRUE,
@@ -36,6 +37,7 @@ tar_quarto(
 tar_quarto_raw(
   name,
   path = ".",
+  output_file = NULL,
   working_directory = NULL,
   extra_files = character(0),
   execute = TRUE,
@@ -67,6 +69,11 @@ argument, and
 \code{\link[=tar_quarto_raw]{tar_quarto_raw()}} expects a character string for \code{name}.}
 
 \item{path}{Character string, path to the Quarto source file.}
+
+\item{output_file}{The name of the output file. If using \code{NULL}, the output
+filename will be based on the filename for the input file. \code{output_file} is
+mapped to the \code{--output} option flag of the \code{quarto} CLI. It is expected to
+be a filename only, not a path, relative or absolute.}
 
 \item{working_directory}{Optional character string,
 path to the working directory


### PR DESCRIPTION
# Prework

* [X ] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [ X] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci/tarchetypes/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted an [issue](http://github.com/ropensci/tarchetypes/issues) or [discussion thread](https://github.com/ropensci/tarchetypes/discussions) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: No direct issue but see #110 .

# Summary

I have a quarto report and want to run it twice with different data sets (targets). Thus, I need some way to specify the output file and set it differently from the default output file. I can do this using quarto profiles but this is a lot of work only for specifying the name of the output file.

In addition, this change makes the `tar_quarto` interface more consistent with `tar_render` which also offers an argument to specify the output file.