### PR TITLE
fix(quarto): detect input files correctly

### DIFF
--- a/R/tar_quarto_files.R
+++ b/R/tar_quarto_files.R
@@ -110,7 +110,10 @@ tar_quarto_files_project <- function(path) {
       # `myfile` is an absolute path.
       myfile,
       # `includeMap` files are relative starting from `myfile`.
-      file.path(dirname(myfile), info$fileInformation[[myfile]]$includeMap$target)
+      file.path(
+        dirname(myfile),
+        info$fileInformation[[myfile]]$includeMap$target
+      )
     )
   }
 

--- a/R/tar_quarto_files.R
+++ b/R/tar_quarto_files.R
@@ -82,8 +82,6 @@ tar_quarto_files_document <- function(path) {
       )
     )
   }
-  # Input `path` is also part of `input`, thus remove it again.
-  out$input <- out$input[out$input != path]
 
   out
 }
@@ -115,8 +113,6 @@ tar_quarto_files_project <- function(path) {
       file.path(dirname(myfile), info$fileInformation[[myfile]]$includeMap$target)
     )
   }
-  # Source files are also part of input, thus remove them.
-  input <- input[!(input %in% sources)]
 
   list(
     sources = sources,

--- a/tests/testthat/test-tar_quarto_files.R
+++ b/tests/testthat/test-tar_quarto_files.R
@@ -16,7 +16,7 @@ targets::tar_test("tar_quarto_files() single Rmd/qmd", {
     out <- tar_quarto_files(path)
     expect_equal(out$sources, file.path("x", paste0("report", ext)))
     expect_equal(out$output, file.path("x", "report.html"))
-    expect_equal(out$input, character(0))
+    expect_equal(out$input, file.path("x", paste0("report", ext)))
   }
 })
 
@@ -62,14 +62,20 @@ targets::tar_test("tar_quarto_files() project", {
       sort(c("index.qmd", "r2.qmd"))
     )
     expect_equal(basename(info$output), "_book")
-    expect_equal(basename(info$input), "_quarto.yml")
+    expect_equal(
+      sort(basename(info$input)),
+      sort(c("_quarto.yml", "index.qmd", "r2.qmd"))
+    )
   } else {
     expect_equal(
       sort(info$sources),
       sort(file.path("x", c("index.qmd", "r2.qmd")))
     )
     expect_equal(info$output, file.path("x", "_book"))
-    expect_equal(info$input, file.path("x", "_quarto.yml"))
+    expect_equal(
+      sort(info$input),
+      sort(file.path("x", c("_quarto.yml", "index.qmd", "r2.qmd")))
+    )
   }
 })
 
@@ -107,7 +113,7 @@ targets::tar_test("tar_quarto_files() detects non-code dependencies", {
     sort(out$input),
     sort(
       c(
-        file.path("report", "text1.qmd"),
+        file.path("report", c("main.qmd", "text1.qmd")),
         file.path("report", "subdir", "text2.qmd")
       )
     )
@@ -127,7 +133,7 @@ targets::tar_test("tar_quarto_files() detects non-code dependencies", {
     expect_equal(basename(out$output), "myoutdir")
     expect_equal(
       sort(basename(out$input)),
-      sort(c("_quarto.yml", "text1.qmd", "text2.qmd"))
+      sort(c("_quarto.yml", "main.qmd", "text1.qmd", "text2.qmd"))
     )
   } else {
     expect_equal(out$sources, file.path("report", "main.qmd"))
@@ -136,8 +142,10 @@ targets::tar_test("tar_quarto_files() detects non-code dependencies", {
       sort(out$input),
       sort(
         c(
-          file.path("report", "_quarto.yml"),
-          file.path("report", "text1.qmd"),
+          file.path(
+            "report",
+            c("_quarto.yml", "main.qmd", "text1.qmd")
+          ),
           file.path("report", "subdir", "text2.qmd")
         )
       )


### PR DESCRIPTION
# Prework

* [X] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [X] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci/tarchetypes/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted an [issue](http://github.com/ropensci/tarchetypes/issues) or [discussion thread](https://github.com/ropensci/tarchetypes/discussions) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: --

# Summary

Currently `tar_quarto_files` does not correctly detect input files. Example:

`main.qmd`:

```r
---
title: "My document"
format:
  html:
    toc: true
---

{{< include "text1.qmd" >}}
```

`text1.qmd`:

```r
# First Text

Some text here.
```

Execute `tar_quarto_files("main.qmd")`. In the results, the `input` section is empty.