### PR TITLE
Fix `tar_quarto()` documentation typo

### DIFF
--- a/R/tar_quarto.R
+++ b/R/tar_quarto.R
@@ -5,10 +5,10 @@
 #'   `targets` pipeline.
 #'
 #'   [tar_quarto()] expects an unevaluated symbol for the `name`
-#'   argument and an unevaluated expression for the `exectue_params` argument.
+#'   argument and an unevaluated expression for the `execute_params` argument.
 #'   [tar_quarto_raw()] expects a character string for the `name`
 #'   argument and an evaluated expression object
-#'   for the `exectue_params` argument.
+#'   for the `execute_params` argument.
 #' @details `tar_quarto()` is an alternative to `tar_target()` for
 #'   Quarto projects and standalone Quarto source documents
 #'   that depend on upstream targets. The Quarto
@@ -76,7 +76,7 @@
 #'   Quarto source files.
 #'
 #'   [tar_quarto()] expects an unevaluated expression for the
-#'   `exectue_params` argument, whereas
+#'   `execute_params` argument, whereas
 #'   [tar_quarto_raw()] expects an evaluated expression object.
 #' @examples
 #' if (identical(Sys.getenv("TAR_LONG_EXAMPLES"), "true")) {

--- a/R/tar_quarto_rep.R
+++ b/R/tar_quarto_rep.R
@@ -5,10 +5,10 @@
 #'   with multiple sets of parameters.
 #'
 #'   [tar_quarto_rep()] expects an unevaluated symbol for the `name`
-#'   argument and an unevaluated expression for the `exectue_params` argument.
+#'   argument and an unevaluated expression for the `execute_params` argument.
 #'   [tar_quarto_rep_raw()] expects a character string for the `name`
 #'   argument and an evaluated expression object
-#'   for the `exectue_params` argument.
+#'   for the `execute_params` argument.
 #' @details `tar_quarto_rep()` is an alternative to `tar_target()` for
 #'   a parameterized Quarto document that depends on other targets.
 #'   Parameters must be given as a data frame with one row per
@@ -61,7 +61,7 @@
 #'   a data frame or `tibble` with one row per rendered report
 #'   and one column per Quarto parameter.
 #'   [tar_quarto_rep()] expects an unevaluated expression for the
-#'   `exectue_params` argument, whereas
+#'   `execute_params` argument, whereas
 #'   [tar_quarto_rep_raw()] expects an evaluated expression object.
 #'
 #'   You may also include an

--- a/man/tar_age.Rd
+++ b/man/tar_age.Rd
@@ -91,7 +91,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_change.Rd
+++ b/man/tar_change.Rd
@@ -38,15 +38,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -134,7 +126,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_combine.Rd
+++ b/man/tar_combine.Rd
@@ -151,7 +151,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_download.Rd
+++ b/man/tar_download.Rd
@@ -39,15 +39,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -120,7 +112,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_file_read.Rd
+++ b/man/tar_file_read.Rd
@@ -38,15 +38,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -118,7 +110,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_files.Rd
+++ b/man/tar_files.Rd
@@ -130,7 +130,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_files_input.Rd
+++ b/man/tar_files_input.Rd
@@ -96,7 +96,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_force.Rd
+++ b/man/tar_force.Rd
@@ -38,15 +38,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -135,7 +127,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_formats.Rd
+++ b/man/tar_formats.Rd
@@ -304,15 +304,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -405,7 +397,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_formats_superseded.Rd
+++ b/man/tar_formats_superseded.Rd
@@ -258,15 +258,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -359,7 +351,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_group_by.Rd
+++ b/man/tar_group_by.Rd
@@ -37,15 +37,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -115,7 +107,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_group_count.Rd
+++ b/man/tar_group_count.Rd
@@ -37,15 +37,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -115,7 +107,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_group_select.Rd
+++ b/man/tar_group_select.Rd
@@ -37,15 +37,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -116,7 +108,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_group_size.Rd
+++ b/man/tar_group_size.Rd
@@ -38,15 +38,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -116,7 +108,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_knit.Rd
+++ b/man/tar_knit.Rd
@@ -88,7 +88,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_map2.Rd
+++ b/man/tar_map2.Rd
@@ -210,7 +210,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_map2_count.Rd
+++ b/man/tar_map2_count.Rd
@@ -217,7 +217,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_map2_size.Rd
+++ b/man/tar_map2_size.Rd
@@ -217,7 +217,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_map_rep.Rd
+++ b/man/tar_map_rep.Rd
@@ -183,7 +183,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_quarto.Rd
+++ b/man/tar_quarto.Rd
@@ -103,7 +103,7 @@ custom elements of the \code{params} list in the YAML front-matter of the
 Quarto source files.
 
 \code{\link[=tar_quarto]{tar_quarto()}} expects an unevaluated expression for the
-\code{exectue_params} argument, whereas
+\code{execute_params} argument, whereas
 \code{\link[=tar_quarto_raw]{tar_quarto_raw()}} expects an evaluated expression object.}
 
 \item{cache}{Cache execution output (uses knitr cache and jupyter-cache
@@ -270,10 +270,10 @@ Shorthand to include a Quarto project in a
 \code{targets} pipeline.
 
 \code{\link[=tar_quarto]{tar_quarto()}} expects an unevaluated symbol for the \code{name}
-argument and an unevaluated expression for the \code{exectue_params} argument.
+argument and an unevaluated expression for the \code{execute_params} argument.
 \code{\link[=tar_quarto_raw]{tar_quarto_raw()}} expects a character string for the \code{name}
 argument and an evaluated expression object
-for the \code{exectue_params} argument.
+for the \code{execute_params} argument.
 }
 \details{
 \code{tar_quarto()} is an alternative to \code{tar_target()} for

--- a/man/tar_quarto.Rd
+++ b/man/tar_quarto.Rd
@@ -146,7 +146,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_quarto_rep.Rd
+++ b/man/tar_quarto_rep.Rd
@@ -91,7 +91,7 @@ these functions will not know where to find the data.}
 a data frame or \code{tibble} with one row per rendered report
 and one column per Quarto parameter.
 \code{\link[=tar_quarto_rep]{tar_quarto_rep()}} expects an unevaluated expression for the
-\code{exectue_params} argument, whereas
+\code{execute_params} argument, whereas
 \code{\link[=tar_quarto_rep_raw]{tar_quarto_rep_raw()}} expects an evaluated expression object.
 
 You may also include an
@@ -303,10 +303,10 @@ Targets to render a parameterized Quarto document
 with multiple sets of parameters.
 
 \code{\link[=tar_quarto_rep]{tar_quarto_rep()}} expects an unevaluated symbol for the \code{name}
-argument and an unevaluated expression for the \code{exectue_params} argument.
+argument and an unevaluated expression for the \code{execute_params} argument.
 \code{\link[=tar_quarto_rep_raw]{tar_quarto_rep_raw()}} expects a character string for the \code{name}
 argument and an evaluated expression object
-for the \code{exectue_params} argument.
+for the \code{execute_params} argument.
 }
 \details{
 \code{tar_quarto_rep()} is an alternative to \code{tar_target()} for

--- a/man/tar_quarto_rep.Rd
+++ b/man/tar_quarto_rep.Rd
@@ -187,7 +187,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_render.Rd
+++ b/man/tar_render.Rd
@@ -87,7 +87,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_render_rep.Rd
+++ b/man/tar_render_rep.Rd
@@ -130,7 +130,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_rep.Rd
+++ b/man/tar_rep.Rd
@@ -154,7 +154,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_rep2.Rd
+++ b/man/tar_rep2.Rd
@@ -159,7 +159,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_rep_map.Rd
+++ b/man/tar_rep_map.Rd
@@ -38,15 +38,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -140,7 +132,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_rep_map_raw.Rd
+++ b/man/tar_rep_map_raw.Rd
@@ -39,15 +39,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -141,7 +133,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.

--- a/man/tar_skip.Rd
+++ b/man/tar_skip.Rd
@@ -38,15 +38,7 @@ must not start with a dot. Subsequent targets
 can refer to this name symbolically to induce a dependency relationship:
 e.g. \code{tar_target(downstream_target, f(upstream_target))} is a
 target named \code{downstream_target} which depends on a target
-\code{upstream_target} and a function \code{f()}.
-
-In most cases, The target name is the name of its local data file
-in storage. Some file systems are not case sensitive, which means
-converting a name to a different case may overwrite a different target.
-Please ensure all target names have unique names when converted to
-lower case.
-
-In addition, a target's
+\code{upstream_target} and a function \code{f()}. In addition, a target's
 name determines its random number generator seed. In this way,
 each target runs with a reproducible seed so someone else
 running the same pipeline should get the same results,
@@ -135,7 +127,7 @@ stops and throws an error. Options:
 \item \code{"null"}: The errored target continues and returns \code{NULL}.
 The data hash is deliberately wrong so the target is not
 up to date for the next run of the pipeline. In addition,
-as of \code{targets} version 1.8.0.9011, a value of \code{NULL} is given
+as of version 1.8.0.9011, a value of \code{NULL} is given
 to upstream dependencies with \code{error = "null"} if loading fails.
 \item \code{"abridge"}: any currently running targets keep running,
 but no new targets launch after that.


### PR DESCRIPTION
# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci/tarchetypes/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted an [issue](http://github.com/ropensci/tarchetypes/issues) or [discussion thread](https://github.com/ropensci/tarchetypes/discussions) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

None

# Summary

Fix a typo in `tar_quarto` documentation.

Prior to fixing the typo (the first commit), I rebuilt the docs where there were many small changes but none were changes that I made (i.e. I didn't change anything, I just ran `devtools::document()`). This was so that the second commit would highlight the typo fix.